### PR TITLE
Add a coloured hydra feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,13 @@ This supercharges your AwesomeWM key bindings by allowing you to control an infi
 ### Key bindings
 The key binding config is a nested table, where each table key is a key ID (see below), and each corresponding value is an table with two required keys: [1], [2], and an optional key: ["color"]
 
-[1]. A string describing the key.
+- [1]. A string describing the key.
 
-[2]. Either:
-
+- [2]. A function OR nested table.
     - A function to be called when the key is pressed. After pressing the key, this function will be called. A green hydra will stay in this level of the key binding config so that other keys at this level can be pressed again as long as the activation key is still held down. A red hydra doesn't require a key to be continuously held down.
     - A nested config table with the same structure as described above. After pressing the key, hydra will go into this level of the key binding config, and the key hints will be updated to show the keys at this level.
 
-['color']. A string. The color of the head: "blue", or "red", or "green"
-
+- ['color']. A string. The color of the head: "blue", or "red", or "green"
     - "blue": the hydra is stopped once the key is pressed and it's corresponding function is run. Use with actions that you intend to run one at a time to ensure the hydra is closed once the function is called after keypress. This will hide the hint popup window and reset the sequence after the key action runs. Mostly useful for red hydras.
 
 Since this is a plain Lua table, you can define the key binding config in any way you like, such as programmatically generating bindings:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # awesome-wm-hydra
 Multi-key-sequence framework for AwesomeWM with key hints display.
 
-It allows you to bind action to a sequence of any number of keys, such as `Super` + `w` + `c`.
+It allows you to bind an action to a sequence of any number of keys, such as `Super` + `w` + `c`.
 
-In the default (green) hydra the sequence resets only when the initial `Super` is released, allowing you to easily implement modal bindings, such as pressing `Super` + `m` for music-related keys then press `h`/`l` multiple-times for seeking while holding down `Super`.
+Within the default behavior `green hydra`, the sequence resets only when the initial activation key eg. `Super` is released, allowing you to easily implement modal bindings, such as pressing `Super` + `m` for music-related keys then press `h`/`l` multiple-times for seeking while holding down `Super`.
 
-Another hydra (red) is available which will keep the key-bindings from the active layer open even after the initial activation key is released. Use the `hydra_color` argument set to `"red"` when calling the `hydra.start` function in your config to avoid the requirement of a held key. A red hydra will reset once an unavailable key is pressed, or a `blue head` is activated.
+A different behavior is available: `red hydra` which will keep the key-bindings and hint display from the active layer open even after the initial activation key is released. Use the `hc` or `color` argument set to `"red"` when calling the `hydra.start` function in your config to avoid the requirement of a held key. A red hydra will reset once an unavailable key is pressed, or a `blue head` is activated.
 
 This supercharges your AwesomeWM key bindings by allowing you to control an infinite number of actions through the keyboard without having to remember them all.
 
@@ -74,7 +74,9 @@ The key binding config is a nested table, where each table key is a key ID (see 
     - A nested config table with the same structure as described above. After pressing the key, hydra will go into this level of the key binding config, and the key hints will be updated to show the keys at this level.
 
 - ["color"]. A string. The color of the head: "blue", or "red", or "green"
-    - "blue": the hydra is stopped once the key is pressed and it's corresponding function is run. Use with actions that you intend to run one at a time to ensure the hydra is closed once the function is called after keypress. This will hide the hint popup window and reset the sequence after the key action runs. Mostly useful for red hydras.
+    - "green": Default. Heads in the current layer can be activated successively without leaving the hydra.
+    - "blue": the hydra is stopped once the key is pressed and it's corresponding function is run. Use for "terminal commands" such as launching applications when you want to close the hydra once the head is activated. This will hide the hint popup window and reset the sequence after the key action runs. Mostly useful for red hydras.
+    - "red": No meaning yet. Head color is independant of the color/behavior of a hydra's body.
 
 Since this is a plain Lua table, you can define the key binding config in any way you like, such as programmatically generating bindings:
 ```lua
@@ -108,8 +110,8 @@ Here are the arguments for the `hydra.start` function:
     - `activation_key`: The trigger key. This is **not** a key ID, but a AwesomeWM key name. This must match the key used in your awesome key config to trigger hydra, since it's used to detect when the activation key is released.
     - `config`: The key binding config table.
 - Optional arguments:
-    - `hydra_color`: The behavior of the hydra. Currently there is a default `"green"` which requires the activation key to be held down and the `"red"` hydra which once activated will stay open with no keys held down.
-    - `ignored_mod`: The modifier to ignore when detecting the activation key. This is **not** a key ID, but a AwesomeWM modifier name. This is useful when the activation key is a modifier key, such as `Mod4` (super key), so that the activation key itself does not have to be specified in the key binding config.
+    - `color`: The behavior of the hydra. Currently there is a default `"green"` which requires the activation key to be held down and the `"red"` hydra which once activated will stay open with no keys held down.
+    - `ignored_mod`: The modifier to ignore when detecting the activation key. This is **not** a key ID, but a AwesomeWM modifier name. This is useful when the activation key is a modifier key, such as `Mod4` (super key), so that the activation key itself does not have to be specified in the key binding config. Can optionally be a table if multiple ignored modifiers are needed.
     - `hide_first_level`: Whether to hide the key hints at the first level. Defaults to `false`.
 - Key hint theme customizations:
     - `key_fg`: The foreground color of the keys.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Multi-key-sequence framework for AwesomeWM with key hints display.
 
 It allows you to bind an action to a sequence of any number of keys, such as `Super` + `w` + `c`.
 
-Within the default behavior `green hydra`, the sequence resets only when the initial activation key eg. `Super` is released, allowing you to easily implement modal bindings, such as pressing `Super` + `m` for music-related keys then press `h`/`l` multiple-times for seeking while holding down `Super`.
+Within the default behavior: `green hydra`, the sequence resets only when the initial activation key, eg. `Super`, is released, allowing you to easily implement modal bindings, such as pressing `Super` + `m` for music-related keys then press `h`/`l` multiple-times for seeking while holding down `Super`.
 
-A different behavior is available: `red hydra` which will keep the key-bindings and hint display from the active layer open even after the initial activation key is released. Use the `hc` or `color` argument set to `"red"` when calling the `hydra.start` function in your config to avoid the requirement of a held key. A red hydra will reset once an unavailable key is pressed, or a `blue head` is activated.
+A different behavior is available: `red hydra`, which will keep the key-bindings and hint display from the active layer open even after the initial activation key is released. Use the `color` argument set to `"red"` when calling the `hydra.start` function in your config to avoid the requirement of a held key. A red hydra will reset once an unavailable key is pressed, or a `blue head` is activated.
 
 This supercharges your AwesomeWM key bindings by allowing you to control an infinite number of actions through the keyboard without having to remember them all.
 
@@ -110,7 +110,7 @@ Here are the arguments for the `hydra.start` function:
     - `activation_key`: The trigger key. This is **not** a key ID, but a AwesomeWM key name. This must match the key used in your awesome key config to trigger hydra, since it's used to detect when the activation key is released.
     - `config`: The key binding config table.
 - Optional arguments:
-    - `color`: The behavior of the hydra. Currently there is a default `"green"` which requires the activation key to be held down and the `"red"` hydra which once activated will stay open with no keys held down.
+    - `color`: The behavior of the hydra. Currently there is a default `"green"` which requires the activation key to be held down, and the `"red"` hydra which once activated will stay open with no keys held down.
     - `ignored_mod`: The modifier to ignore when detecting the activation key. This is **not** a key ID, but a AwesomeWM modifier name. This is useful when the activation key is a modifier key, such as `Mod4` (super key), so that the activation key itself does not have to be specified in the key binding config. Can optionally be a table if multiple ignored modifiers are needed.
     - `hide_first_level`: Whether to hide the key hints at the first level. Defaults to `false`.
 - Key hint theme customizations:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The key binding config is a nested table, where each table key is a key ID (see 
     - A function to be called when the key is pressed. After pressing the key, this function will be called. A green hydra will stay in this level of the key binding config so that other keys at this level can be pressed again as long as the activation key is still held down. A red hydra doesn't require a key to be continuously held down.
     - A nested config table with the same structure as described above. After pressing the key, hydra will go into this level of the key binding config, and the key hints will be updated to show the keys at this level.
 
-- ['color']. A string. The color of the head: "blue", or "red", or "green"
+- ["color"]. A string. The color of the head: "blue", or "red", or "green"
     - "blue": the hydra is stopped once the key is pressed and it's corresponding function is run. Use with actions that you intend to run one at a time to ensure the hydra is closed once the function is called after keypress. This will hide the hint popup window and reset the sequence after the key action runs. Mostly useful for red hydras.
 
 Since this is a plain Lua table, you can define the key binding config in any way you like, such as programmatically generating bindings:
@@ -105,10 +105,10 @@ Use `hydra.hidden` as the description string to hide the key from key hints. Thi
 ### Main trigger arguments
 Here are the arguments for the `hydra.start` function:
 - Required arguments:
-    - `hydra_color`: The behavior of the hydra. Currently there is a default `"green"` which requires the activation key to be held down and the `"red"` hydra which once activated will stay open with no keys held down.
     - `activation_key`: The trigger key. This is **not** a key ID, but a AwesomeWM key name. This must match the key used in your awesome key config to trigger hydra, since it's used to detect when the activation key is released.
     - `config`: The key binding config table.
 - Optional arguments:
+    - `hydra_color`: The behavior of the hydra. Currently there is a default `"green"` which requires the activation key to be held down and the `"red"` hydra which once activated will stay open with no keys held down.
     - `ignored_mod`: The modifier to ignore when detecting the activation key. This is **not** a key ID, but a AwesomeWM modifier name. This is useful when the activation key is a modifier key, such as `Mod4` (super key), so that the activation key itself does not have to be specified in the key binding config.
     - `hide_first_level`: Whether to hide the key hints at the first level. Defaults to `false`.
 - Key hint theme customizations:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # awesome-wm-hydra
 Multi-key-sequence framework for AwesomeWM with key hints display.
 
-It allows you to bind action to a sequence of any number of keys, such as `Super` + `w` + `c`. The sequence resets only when the initial `Super` is released, allowing you to easily implement modal bindings, such as pressing `Super` + `m` for music-related keys then press `h`/`l` multiple-times for seeking while holding down `Super`.
+It allows you to bind action to a sequence of any number of keys, such as `Super` + `w` + `c`.
+
+In the default (green) mode the sequence resets only when the initial `Super` is released, allowing you to easily implement modal bindings, such as pressing `Super` + `m` for music-related keys then press `h`/`l` multiple-times for seeking while holding down `Super`.
+
+Another mode (red) is available which will keep the hydra open even after the initial activation key is released. Use the `hydra_color` argument set to `"red"` when calling the `hydra.start` function in your config to avoid holding down an extra key. A red hydra will reset once an unavailable key is pressed, or a blue head is activated.
 
 This supercharges your AwesomeWM key bindings by allowing you to control an infinite number of actions through the keyboard without having to remember them all.
 
@@ -61,16 +65,19 @@ This supercharges your AwesomeWM key bindings by allowing you to control an infi
 ## Configuration
 
 ### Key bindings
-The key binding config is a nested table, where each table key is a key ID (see below), and each corresponding value is an array with two elements:
+The key binding config is a nested table, where each table key is a key ID (see below), and each corresponding value is an table with two required keys: [1], [2], and an optional key: ["color"]
 1. A string describing the key.
 2. Either:
-    - A function to be called when the key is pressed. After pressing the key, this function will be called, and hydra will stay in this level of the key binding config so that other keys at this level can be pressed again as long as the activation key is still held down.
+    - A function to be called when the key is pressed. After pressing the key, this function will be called. A green hydra will stay in this level of the key binding config so that other keys at this level can be pressed again as long as the activation key is still held down. A red hydra doesn't require a key to be continuously held down.
     - A nested config table with the same structure as described above. After pressing the key, hydra will go into this level of the key binding config, and the key hints will be updated to show the keys at this level.
+'color'. A string: "blue", or "red", or "green"
+    - "blue": the hydra is stopped once the key is pressed and it's corresponding function is run. Use with actions that you intend to run one at a time to ensure the hydra is closed once the function is called after keypress. This will hide the hint popup window and reset the sequence after the key action runs. Useful only for red hydras.
 
 Since this is a plain Lua table, you can define the key binding config in any way you like, such as programmatically generating bindings:
 ```lua
 for i = 1, 9 do
     super_key_bindings[tostring(i)] = {
+        color = "blue",
         "view tag " .. i,
         function()
             local tag = awful.screen.focused().tags[i]
@@ -95,6 +102,7 @@ Use `hydra.hidden` as the description string to hide the key from key hints. Thi
 ### Main trigger arguments
 Here are the arguments for the `hydra.start` function:
 - Required arguments:
+    - `hydra_color`: The behavior of the hydra. Currently there is a default `"green"` which requires the activation key to be held down and the `"red"` hydra which once activated will stay open with no keys held down.
     - `activation_key`: The trigger key. This is **not** a key ID, but a AwesomeWM key name. This must match the key used in your awesome key config to trigger hydra, since it's used to detect when the activation key is released.
     - `config`: The key binding config table.
 - Optional arguments:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Multi-key-sequence framework for AwesomeWM with key hints display.
 
 It allows you to bind action to a sequence of any number of keys, such as `Super` + `w` + `c`.
 
-In the default (green) mode the sequence resets only when the initial `Super` is released, allowing you to easily implement modal bindings, such as pressing `Super` + `m` for music-related keys then press `h`/`l` multiple-times for seeking while holding down `Super`.
+In the default (green) hydra the sequence resets only when the initial `Super` is released, allowing you to easily implement modal bindings, such as pressing `Super` + `m` for music-related keys then press `h`/`l` multiple-times for seeking while holding down `Super`.
 
-Another mode (red) is available which will keep the hydra open even after the initial activation key is released. Use the `hydra_color` argument set to `"red"` when calling the `hydra.start` function in your config to avoid the requirement of a held key. A red hydra will reset once an unavailable key is pressed, or a `blue head` is activated.
+Another hydra (red) is available which will keep the key-bindings from the active layer open even after the initial activation key is released. Use the `hydra_color` argument set to `"red"` when calling the `hydra.start` function in your config to avoid the requirement of a held key. A red hydra will reset once an unavailable key is pressed, or a `blue head` is activated.
 
 This supercharges your AwesomeWM key bindings by allowing you to control an infinite number of actions through the keyboard without having to remember them all.
 
@@ -66,11 +66,11 @@ This supercharges your AwesomeWM key bindings by allowing you to control an infi
 
 ### Key bindings
 The key binding config is a nested table, where each table key is a key ID (see below), and each corresponding value is an table with two required keys: [1], [2], and an optional key: ["color"]
-1. A string describing the key.
-2. Either:
+[1]. A string describing the key.
+[2]. Either:
     - A function to be called when the key is pressed. After pressing the key, this function will be called. A green hydra will stay in this level of the key binding config so that other keys at this level can be pressed again as long as the activation key is still held down. A red hydra doesn't require a key to be continuously held down.
     - A nested config table with the same structure as described above. After pressing the key, hydra will go into this level of the key binding config, and the key hints will be updated to show the keys at this level.
-'color'. The color of the head; a string: "blue", or "red", or "green"
+['color']. The color of the head; a string: "blue", or "red", or "green"
     - "blue": the hydra is stopped once the key is pressed and it's corresponding function is run. Use with actions that you intend to run one at a time to ensure the hydra is closed once the function is called after keypress. This will hide the hint popup window and reset the sequence after the key action runs. Mostly useful for red hydras.
 
 Since this is a plain Lua table, you can define the key binding config in any way you like, such as programmatically generating bindings:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It allows you to bind action to a sequence of any number of keys, such as `Super
 
 In the default (green) mode the sequence resets only when the initial `Super` is released, allowing you to easily implement modal bindings, such as pressing `Super` + `m` for music-related keys then press `h`/`l` multiple-times for seeking while holding down `Super`.
 
-Another mode (red) is available which will keep the hydra open even after the initial activation key is released. Use the `hydra_color` argument set to `"red"` when calling the `hydra.start` function in your config to avoid holding down an extra key. A red hydra will reset once an unavailable key is pressed, or a blue head is activated.
+Another mode (red) is available which will keep the hydra open even after the initial activation key is released. Use the `hydra_color` argument set to `"red"` when calling the `hydra.start` function in your config to avoid the requirement of a held key. A red hydra will reset once an unavailable key is pressed, or a `blue head` is activated.
 
 This supercharges your AwesomeWM key bindings by allowing you to control an infinite number of actions through the keyboard without having to remember them all.
 
@@ -70,8 +70,8 @@ The key binding config is a nested table, where each table key is a key ID (see 
 2. Either:
     - A function to be called when the key is pressed. After pressing the key, this function will be called. A green hydra will stay in this level of the key binding config so that other keys at this level can be pressed again as long as the activation key is still held down. A red hydra doesn't require a key to be continuously held down.
     - A nested config table with the same structure as described above. After pressing the key, hydra will go into this level of the key binding config, and the key hints will be updated to show the keys at this level.
-'color'. A string: "blue", or "red", or "green"
-    - "blue": the hydra is stopped once the key is pressed and it's corresponding function is run. Use with actions that you intend to run one at a time to ensure the hydra is closed once the function is called after keypress. This will hide the hint popup window and reset the sequence after the key action runs. Useful only for red hydras.
+'color'. The color of the head; a string: "blue", or "red", or "green"
+    - "blue": the hydra is stopped once the key is pressed and it's corresponding function is run. Use with actions that you intend to run one at a time to ensure the hydra is closed once the function is called after keypress. This will hide the hint popup window and reset the sequence after the key action runs. Mostly useful for red hydras.
 
 Since this is a plain Lua table, you can define the key binding config in any way you like, such as programmatically generating bindings:
 ```lua

--- a/README.md
+++ b/README.md
@@ -66,11 +66,16 @@ This supercharges your AwesomeWM key bindings by allowing you to control an infi
 
 ### Key bindings
 The key binding config is a nested table, where each table key is a key ID (see below), and each corresponding value is an table with two required keys: [1], [2], and an optional key: ["color"]
+
 [1]. A string describing the key.
+
 [2]. Either:
+
     - A function to be called when the key is pressed. After pressing the key, this function will be called. A green hydra will stay in this level of the key binding config so that other keys at this level can be pressed again as long as the activation key is still held down. A red hydra doesn't require a key to be continuously held down.
     - A nested config table with the same structure as described above. After pressing the key, hydra will go into this level of the key binding config, and the key hints will be updated to show the keys at this level.
-['color']. The color of the head; a string: "blue", or "red", or "green"
+
+['color']. A string. The color of the head: "blue", or "red", or "green"
+
     - "blue": the hydra is stopped once the key is pressed and it's corresponding function is run. Use with actions that you intend to run one at a time to ensure the hydra is closed once the function is called after keypress. This will hide the hint popup window and reset the sequence after the key action runs. Mostly useful for red hydras.
 
 Since this is a plain Lua table, you can define the key binding config in any way you like, such as programmatically generating bindings:

--- a/init.lua
+++ b/init.lua
@@ -1,310 +1,351 @@
 local gears = require("gears")
-local awful = require('awful')
+local awful = require("awful")
 local beautiful = require("beautiful")
 local naughty = require("naughty")
 local wibox = require("wibox")
 local math = require("math")
-local dpi   = require("beautiful.xresources").apply_dpi
+local dpi = require("beautiful.xresources").apply_dpi
 
+local key_table_froms_list = function(t)
+	local result = {}
+	for i, v in ipairs(t) do
+		result[v] = i
+	end
+	return result
+end
 --- Cached objects
 local wbox
 local title_widget
 local layout_widgets
 local num_columns = 3
+local hydra_colors = key_table_froms_list({
+	"red",
+	"green",
+	"blue",
+	"amaranth",
+})
 
 local hidden = {}
 
 local function debug_print(str)
-    naughty.notify({ preset = naughty.config.presets.normal,
-                     title = "Debug",
-                     text = str })
+	naughty.notify({
+		preset = naughty.config.presets.normal,
+		title = "Debug",
+		text = str,
+	})
 end
 
 local function print_error(str)
-    naughty.notify({ preset = naughty.config.presets.critical,
-                     title = "Error",
-                     text = str })
+	naughty.notify({
+		preset = naughty.config.presets.critical,
+		title = "Error",
+		text = str,
+	})
 end
 
 local function key_to_string(mod, key)
-    if key == " " then
-        key = "space"
-    end
+	if key == " " then
+		key = "space"
+	end
 
-    local mod_copy = {}
-    for _, modifier in ipairs(mod) do
-        table.insert(mod_copy, modifier)
-    end
+	local mod_copy = {}
+	for _, modifier in ipairs(mod) do
+		table.insert(mod_copy, modifier)
+	end
 
-    table.sort(mod_copy)
+	table.sort(mod_copy)
 
-    if #mod_copy > 0 then
-        key = table.concat(mod_copy, "-") .. "-" .. key
-    end
-    -- to lower case
-    key = key:lower()
-    return key
+	if #mod_copy > 0 then
+		key = table.concat(mod_copy, "-") .. "-" .. key
+	end
+	-- to lower case
+	key = key:lower()
+	return key
 end
 
 local function colorize(text, fg, bg)
-    if fg == nil then
-        fg = ""
-    else
-        fg = " foreground=\"" .. fg .. "\""
-    end
-    if bg == nil then
-        bg = ""
-    else
-        bg = " background=\"" .. bg .. "\""
-    end
-    return "<span" .. fg .. bg .. ">" .. text .. "</span>"
+	if fg == nil then
+		fg = ""
+	else
+		fg = ' foreground="' .. fg .. '"'
+	end
+	if bg == nil then
+		bg = ""
+	else
+		bg = ' background="' .. bg .. '"'
+	end
+	return "<span" .. fg .. bg .. ">" .. text .. "</span>"
 end
 
 local function bold(text)
-    return "<b>" .. text .. "</b>"
+	return "<b>" .. text .. "</b>"
 end
 
 local function escape_markup(text)
-    return text:gsub("&", "&amp;"):gsub("<", "&lt;"):gsub(">", "&gt;")
+	return text:gsub("&", "&amp;"):gsub("<", "&lt;"):gsub(">", "&gt;")
 end
 
 local function start(args)
-    local config = args.config
-    if not config then
-        error("config not given")
-    end
-    local activation_key = args.activation_key
-    if not activation_key then
-        error("activation_key not given")
-    end
-    local ignored_mod = args.ignored_mod or nil
-    local hide_first_level = args.hide_first_level or false
-    local key_fg = args.key_fg or beautiful.fg_normal
-    local key_bg = args.key_bg or "#eeeeee"
-    local key_control_fg = args.key_control_fg or "#00bb00"
-    local key_shift_fg = args.key_shift_fg or "#4488ff"
-    local key_modifier_fg = args.key_modifier_fg or "#aa4444"
-    local activation_fg = args.activation_fg or "#44aaff"
-    local nested_fg = args.nested_fg or "#4488aa"
-    local nested_bg = args.nested_bg or nil
-    local focused_fg = args.focused_fg or nil
-    local focused_bg = args.focused_bg or "#dddddd"
+	local config = args.config
+	if not config then
+		error("config not given")
+	end
+	local activation_key = args.activation_key
+	if not activation_key then
+		error("activation_key not given")
+	end
+	local current_hydra_color
+	if args.hydra_color then
+		current_hydra_color = hydra_colors[args.hydra_color]
+		if not current_hydra_color then
+			error("invalid hydra_color; allowed: 'red', 'green', blue', 'amaranth'")
+		end
+	else
+		current_hydra_color = hydra_colors.green
+	end
 
-    local current_key_table = config
-    local breadcrumbs = {}
-    local focused_key = nil
+	local current_key_table = config
+	current_hydra_color = current_key_table.color and hydra_colors[current_key_table.color] or current_hydra_color
 
-    local initial_screen = awful.screen.focused()
+	local ignored_mod = args.ignored_mod or nil
+	local hide_first_level = args.hide_first_level or false
+	local key_fg = args.key_fg or beautiful.fg_normal
+	local key_bg = args.key_bg or "#eeeeee"
+	local key_control_fg = args.key_control_fg or "#00bb00"
+	local key_shift_fg = args.key_shift_fg or "#4488ff"
+	local key_modifier_fg = args.key_modifier_fg or "#aa4444"
+	local activation_fg = args.activation_fg or "#44aaff"
+	local nested_fg = args.nested_fg or "#4488aa"
+	local nested_bg = args.nested_bg or nil
+	local focused_fg = args.focused_fg or nil
+	local focused_bg = args.focused_bg or "#dddddd"
 
-    local margin_size = dpi(6)
-    local title_height = dpi(22)
-    local key_height = dpi(15)
-    local main_width = dpi(800)
-    local y_anchor_pos = 0.75
+	local breadcrumbs = {}
+	local focused_key = nil
 
-    local colorized_control = colorize("C", key_control_fg)
-    local colorized_shift = colorize("S", key_shift_fg)
-    local colorized_mod1 = colorize("A", key_modifier_fg)
-    local colorized_mod4 = colorize("Super", key_modifier_fg)
-    local colorized_mod3 = colorize("Mod3", key_modifier_fg)
+	local initial_screen = awful.screen.focused()
 
-    local function key_string_to_label(key_string)
-        key_string = key_string:gsub("control", colorized_control)
-        key_string = key_string:gsub("shift", colorized_shift)
-        key_string = key_string:gsub("mod1", colorized_mod1)
-        key_string = key_string:gsub("mod4", colorized_mod4)
-        key_string = key_string:gsub("mod3", colorized_mod3)
-        return colorize(bold(" " .. key_string .. " "), key_fg, key_bg)
-    end
+	local margin_size = dpi(6)
+	local title_height = dpi(22)
+	local key_height = dpi(15)
+	local main_width = dpi(800)
+	local y_anchor_pos = 0.75
 
-    local function stylize_nested(description)
-        return colorize(bold(description), nested_fg, nested_bg)
-    end
-    
-    local function update_ui()
-        if hide_first_level and #breadcrumbs == 0 then
-            return
-        end
+	local colorized_control = colorize("C", key_control_fg)
+	local colorized_shift = colorize("S", key_shift_fg)
+	local colorized_mod1 = colorize("A", key_modifier_fg)
+	local colorized_mod4 = colorize("Super", key_modifier_fg)
+	local colorized_mod3 = colorize("Mod3", key_modifier_fg)
 
-        if not wbox then
-            wbox = wibox({
-                ontop = true,
-                type="dock",
-                border_width = beautiful.border_width,
-                border_color = beautiful.border_focus,
-                placement = awful.placement.centered,
-            })
-            wbox.screen = initial_screen
-            wbox:set_fg(beautiful.fg_normal)
-            wbox:set_bg(beautiful.bg_normal..'e2')
+	local function key_string_to_label(key_string)
+		key_string = key_string:gsub("control", colorized_control)
+		key_string = key_string:gsub("shift", colorized_shift)
+		key_string = key_string:gsub("mod1", colorized_mod1)
+		key_string = key_string:gsub("mod4", colorized_mod4)
+		key_string = key_string:gsub("mod3", colorized_mod3)
+		return colorize(bold(" " .. key_string .. " "), key_fg, key_bg)
+	end
 
-            local container_inner = wibox.layout.align.vertical()
-            local container_layout = wibox.container.margin(
-                container_inner,
-                margin_size, margin_size,
-                margin_size, margin_size)
-            container_layout = wibox.container.background(container_layout)
+	local function stylize_nested(description)
+		return colorize(bold(description), nested_fg, nested_bg)
+	end
 
-            wbox:set_widget(container_layout)
-            layout_widgets = {}
-            for i = 1, num_columns do
-                local layout_widget = wibox.layout.fixed.vertical()
-                table.insert(layout_widgets, layout_widget)
-            end
-            title_widget = wibox.widget {
-                markup = "",
-                valign = "bottom",
-                align = "center",
-                forced_height = title_height,
-                widget = wibox.widget.textbox,
-            }
-            container_inner:set_bottom(title_widget)
-            local args = {
-                layout = wibox.layout.flex.horizontal,
-                forced_width = main_width,
-            }
-            for _, layout_widget in ipairs(layout_widgets) do
-                table.insert(args, layout_widget)
-            end
-            container_inner:set_middle(wibox.widget(args))
-        else
-            for _, layout_widget in ipairs(layout_widgets) do
-                layout_widget:reset()
-            end
-        end
+	local function update_ui()
+		if hide_first_level and #breadcrumbs == 0 then
+			return
+		end
 
-        -- build title widget markup using breadcrumbs
-        local title_markup = colorize(bold(activation_key), activation_fg)
-        for i, v in ipairs(breadcrumbs) do
-            title_markup = title_markup .. " " .. key_string_to_label(escape_markup(v[1]))
-        end
-        if #breadcrumbs > 0 then
-            local v = breadcrumbs[#breadcrumbs]
-            title_markup = title_markup .. " - " .. stylize_nested(escape_markup(v[2]))
-        end
-        title_widget.markup = title_markup
+		if not wbox then
+			wbox = wibox({
+				ontop = true,
+				type = "dock",
+				border_width = beautiful.border_width,
+				border_color = beautiful.border_focus,
+				placement = awful.placement.centered,
+			})
+			wbox.screen = initial_screen
+			wbox:set_fg(beautiful.fg_normal)
+			wbox:set_bg(beautiful.bg_normal .. "e2")
 
-        -- Set geometry always, the screen might have changed.
-        local wa = initial_screen.workarea
-        local x = math.ceil(wa.x + wa.width / 2 - main_width / 2) -- Center align
-        wbox:geometry({
-            x = x,
-            width = main_width,
-        })
-        local wbox_height = title_height
+			local container_inner = wibox.layout.align.vertical()
+			local container_layout =
+				wibox.container.margin(container_inner, margin_size, margin_size, margin_size, margin_size)
+			container_layout = wibox.container.background(container_layout)
 
-        local keys = {}
-        for k, _ in pairs(current_key_table) do
-            table.insert(keys, {k, key_string_to_label(escape_markup(k))})
-        end
-        table.sort(keys, function(a, b) return a[2] < b[2] end)
+			wbox:set_widget(container_layout)
+			layout_widgets = {}
+			for i = 1, num_columns do
+				local layout_widget = wibox.layout.fixed.vertical()
+				table.insert(layout_widgets, layout_widget)
+			end
+			title_widget = wibox.widget({
+				markup = "",
+				valign = "bottom",
+				align = "center",
+				forced_height = title_height,
+				widget = wibox.widget.textbox,
+			})
+			container_inner:set_bottom(title_widget)
+			local args = {
+				layout = wibox.layout.flex.horizontal,
+				forced_width = main_width,
+			}
+			for _, layout_widget in ipairs(layout_widgets) do
+				table.insert(args, layout_widget)
+			end
+			container_inner:set_middle(wibox.widget(args))
+		else
+			for _, layout_widget in ipairs(layout_widgets) do
+				layout_widget:reset()
+			end
+		end
 
-        -- loop through each key
-        local current_column = 1
-        for _, entry in ipairs(keys) do
-            local k = entry[1]
-            local label = entry[2]
-            local v = current_key_table[k]
-            local description = v[1]
-            if description == hidden then
-                -- skip hidden keys
-                goto continue
-            end
-            description = escape_markup(description)
-            local child = v[2]
-            local child_is_function = type(child) == "function"
-            if not child_is_function then
-                description = stylize_nested(description .. "...")
-            end
-            local height = key_height
-            local markup = label .. " - " .. description
-            if focused_key == k then
-                markup = colorize(markup, focused_fg, focused_bg)
-            end
-            local key_widget = wibox.widget {
-                markup = markup,
-                valign = "center",
-                align = "left",
-                forced_height = height,
-                widget = wibox.widget.textbox,
-            }
-            layout_widgets[current_column]:add(key_widget)
-            if current_column == 1 then
-                wbox_height = wbox_height + height
-            end
-            current_column = current_column + 1
-            if current_column > num_columns then
-                current_column = 1
-            end
-            ::continue::
-        end
+		-- build title widget markup using breadcrumbs
+		local title_markup = colorize(bold(activation_key), activation_fg)
+		for i, v in ipairs(breadcrumbs) do
+			title_markup = title_markup .. " " .. key_string_to_label(escape_markup(v[1]))
+		end
+		if #breadcrumbs > 0 then
+			local v = breadcrumbs[#breadcrumbs]
+			title_markup = title_markup .. " - " .. stylize_nested(escape_markup(v[2]))
+		end
+		title_widget.markup = title_markup
 
-        local h = wbox_height + margin_size * 2
-        wbox.screen = initial_screen
-        wbox:geometry({
-            height = h,
-            y = wa.y + wa.height * y_anchor_pos - h,
-        })
-        wbox.visible = true
-    end
+		-- Set geometry always, the screen might have changed.
+		local wa = initial_screen.workarea
+		local x = math.ceil(wa.x + wa.width / 2 - main_width / 2) -- Center align
+		wbox:geometry({
+			x = x,
+			width = main_width,
+		})
+		local wbox_height = title_height
 
-    local grabber
+		local keys = {}
+		for k, _ in pairs(current_key_table) do
+			table.insert(keys, { k, key_string_to_label(escape_markup(k)) })
+		end
+		table.sort(keys, function(a, b)
+			return a[2] < b[2]
+		end)
 
-    local function stop()
-        if wbox then
-            wbox.visible = false
-        end
-        awful.keygrabber.stop(grabber)
-        grabber = nil
-        breadcrumbs = {}
-    end
+		-- loop through each key
+		local current_column = 1
+		for _, entry in ipairs(keys) do
+			local k = entry[1]
+			local label = entry[2]
+			local v = current_key_table[k]
+			local description = v[1]
+			if description ~= hidden then
+				description = escape_markup(description)
+				local child = v[2]
+				local child_is_function = type(child) == "function"
+				if not child_is_function then
+					description = stylize_nested(description .. "...")
+				end
+				local height = key_height
+				local markup = label .. " - " .. description
+				if focused_key == k then
+					markup = colorize(markup, focused_fg, focused_bg)
+				end
+				local key_widget = wibox.widget({
+					markup = markup,
+					valign = "center",
+					align = "left",
+					forced_height = height,
+					widget = wibox.widget.textbox,
+				})
+				layout_widgets[current_column]:add(key_widget)
+				if current_column == 1 then
+					wbox_height = wbox_height + height
+				end
+				current_column = current_column + 1
+				if current_column > num_columns then
+					current_column = 1
+				end
+			end
+		end
 
-    update_ui()
+		local h = wbox_height + margin_size * 2
+		wbox.screen = initial_screen
+		wbox:geometry({
+			height = h,
+			y = wa.y + wa.height * y_anchor_pos - h,
+		})
+		wbox.visible = true
+	end
 
-    grabber = awful.keygrabber.run(function(mod, key, event)
-        if event == "release" then
-            if key == activation_key then
-                stop()
-            end
-            return
-        end
+	local grabber
 
-        local mod_copy = {}
-        for _, modifier in ipairs(mod) do
-            if modifier ~= ignored_mod and modifier ~= "Mod2" then
-                table.insert(mod_copy, modifier)
-            end
-        end
-        mod = mod_copy
+	local function stop()
+		if wbox then
+			wbox.visible = false
+		end
+		awful.keygrabber.stop(grabber)
+		grabber = nil
+		breadcrumbs = {}
+	end
 
-        local key_string = key_to_string(mod, key)
-        -- debug_print("grabber: mod: " .. table.concat(mod, ',')
-        --     .. ", key: " .. tostring(key)
-        --     .. ", event: " .. tostring(event)
-        --     .. ", key_string: " .. key_string)
+	update_ui()
 
-        local child = current_key_table[key_string]
-        if child then
-            local description = child[1]
-            child = child[2]
-            if type(child) == "function" then
-                local status, err = pcall(child)
-                if not status then
-                    print_error("Error: " .. err)
-                end
-                focused_key = key_string
-                update_ui()
-            else
-                table.insert(breadcrumbs, {key, description})
-                current_key_table = child
-                focused_key = nil
-                update_ui()
-            end
-        end
-    end)
+	grabber = awful.keygrabber.run(function(mod, key, event)
+		if event == "release" then
+			if current_hydra_color == hydra_colors.green then
+				if key == activation_key then
+					stop()
+				end
+			end
+			return
+		end
+
+		local mod_copy = {}
+		for _, modifier in ipairs(mod) do
+			if modifier ~= ignored_mod and modifier ~= "Mod2" then
+				table.insert(mod_copy, modifier)
+			end
+		end
+		mod = mod_copy
+
+		local key_string = key_to_string(mod, key)
+		-- debug_print("grabber: mod: " .. table.concat(mod, ',')
+		--     .. ", key: " .. tostring(key)
+		--     .. ", event: " .. tostring(event)
+		--     .. ", key_string: " .. key_string)
+
+		local child = current_key_table[key_string]
+
+		if not child then
+			if current_hydra_color == hydra_colors.red then
+				if key_string ~= activation_key or key_string ~= ignored_mod then
+					stop()
+				end
+			end
+		else
+			local description = child[1]
+			local child_color = child.color and hydra_colors[child.color] or current_hydra_color
+			child = child[2]
+			if type(child) == "function" then
+				local status, err = pcall(child)
+				-- if not status then (unused status)
+				if err then
+					print_error("Error: " .. err)
+				end
+				focused_key = key_string
+				update_ui()
+				if child_color == hydra_colors.blue then
+					stop()
+				end
+			else
+				table.insert(breadcrumbs, { key, description })
+				current_key_table = child
+				focused_key = nil
+				update_ui()
+			end
+		end
+	end)
 end
 
 return {
-    start = start,
-    hidden = hidden,
+	start = start,
+	hidden = hidden,
 }
+


### PR DESCRIPTION
Red hydras do not require the activation key to be held down while the sequence is typed. The hydra will remain open until a key which is not part of the active layer is pressed. Heads marked with a "blue" color value will be closed after the action is activated and unmarked heads will remain open.

The hydra will default to "green" if a color key value is not supplied in the args. A green hydra will behave as the original behavior of this plugin.